### PR TITLE
add validations to crd with enums

### DIFF
--- a/charts/elasti/templates/elastiservice-crd.yaml
+++ b/charts/elasti/templates/elastiservice-crd.yaml
@@ -65,6 +65,9 @@ spec:
                   Important: Run "make" to regenerate code after modifying this file
                 properties:
                   apiVersion:
+                    enum:
+                      - apps/v1
+                      - argoproj.io/v1alpha1
                     type: string
                   kind:
                     enum:

--- a/charts/elasti/templates/elastiservice-crd.yaml
+++ b/charts/elasti/templates/elastiservice-crd.yaml
@@ -45,6 +45,9 @@ spec:
                   name:
                     type: string
                   type:
+                    enum:
+                      - hpa
+                      - keda
                     type: string
                 required:
                   - name
@@ -64,6 +67,9 @@ spec:
                   apiVersion:
                     type: string
                   kind:
+                    enum:
+                      - deployments
+                      - rollouts
                     type: string
                   name:
                     type: string
@@ -76,6 +82,8 @@ spec:
                     metadata:
                       x-kubernetes-preserve-unknown-fields: true
                     type:
+                      enum:
+                        - prometheus
                       type: string
                   required:
                     - type

--- a/operator/api/v1alpha1/elastiservice_types.go
+++ b/operator/api/v1alpha1/elastiservice_types.go
@@ -43,8 +43,9 @@ type ElastiServiceSpec struct {
 
 type ScaleTargetRef struct {
 	APIVersion string `json:"apiVersion,omitempty"`
-	Kind       string `json:"kind,omitempty"`
-	Name       string `json:"name,omitempty"`
+	// +kubebuilder:validation:Enum=deployments;rollouts
+	Kind string `json:"kind,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // ElastiServiceStatus defines the observed state of ElastiService
@@ -78,6 +79,7 @@ type ElastiServiceList struct {
 }
 
 type ScaleTrigger struct {
+	// +kubebuilder:validation:Enum=prometheus
 	Type string `json:"type"`
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Schemaless
@@ -85,7 +87,8 @@ type ScaleTrigger struct {
 }
 
 type AutoscalerSpec struct {
-	Type string `json:"type"` // keda/hpa
+	// +kubebuilder:validation:Enum=hpa;keda
+	Type string `json:"type"`
 	Name string `json:"name"` // Name of the ScaledObject/HorizontalPodAutoscaler
 }
 

--- a/operator/api/v1alpha1/elastiservice_types.go
+++ b/operator/api/v1alpha1/elastiservice_types.go
@@ -42,6 +42,7 @@ type ElastiServiceSpec struct {
 }
 
 type ScaleTargetRef struct {
+	// +kubebuilder:validation:Enum=apps/v1;argoproj.io/v1alpha1
 	APIVersion string `json:"apiVersion,omitempty"`
 	// +kubebuilder:validation:Enum=deployments;rollouts
 	Kind string `json:"kind,omitempty"`

--- a/operator/config/crd/bases/elasti.truefoundry.com_elastiservices.yaml
+++ b/operator/config/crd/bases/elasti.truefoundry.com_elastiservices.yaml
@@ -64,6 +64,9 @@ spec:
                   Important: Run "make" to regenerate code after modifying this file
                 properties:
                   apiVersion:
+                    enum:
+                    - apps/v1
+                    - argoproj.io/v1alpha1
                     type: string
                   kind:
                     enum:

--- a/operator/config/crd/bases/elasti.truefoundry.com_elastiservices.yaml
+++ b/operator/config/crd/bases/elasti.truefoundry.com_elastiservices.yaml
@@ -44,6 +44,9 @@ spec:
                   name:
                     type: string
                   type:
+                    enum:
+                    - hpa
+                    - keda
                     type: string
                 required:
                 - name
@@ -63,6 +66,9 @@ spec:
                   apiVersion:
                     type: string
                   kind:
+                    enum:
+                    - deployments
+                    - rollouts
                     type: string
                   name:
                     type: string
@@ -75,6 +81,8 @@ spec:
                     metadata:
                       x-kubernetes-preserve-unknown-fields: true
                     type:
+                      enum:
+                      - prometheus
                       type: string
                   required:
                   - type


### PR DESCRIPTION
## Description
Added enum validations to the ElastiService CRD:
- ```scaleTargetRef.kind```: Restricts to "deployments" or "rollouts"
- ```autoscaler.type```: Restricts to "hpa" or "keda"
- ```triggers[].type```: Restricts to "prometheus"
- ```scaleTargetRef.apiVersion```: Restricts to "apps/v1" or "argoproj.io/v1alpha1"

Fixes [TT-11339](https://truefoundry.atlassian.net/browse/TT-11339)

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

## Checklist:
- [x] I have performed a self-review of my own code
