### PR TITLE
replace sentry *fmt.wrapError with logger error

### DIFF
--- a/operator/internal/controller/elastiservice_controller.go
+++ b/operator/internal/controller/elastiservice_controller.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/getsentry/sentry-go"
 	"github.com/truefoundry/elasti/pkg/scaling"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -74,7 +73,7 @@ func (r *ElastiServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		e := values.Success
 		if err != nil {
 			e = err.Error()
-			sentry.CaptureException(err)
+			r.Logger.Error("Error reconciling ElastiService.", zap.String("es", req.NamespacedName.String()), zap.Error(err))
 		}
 		duration := time.Since(startTime).Seconds()
 		prom.CRDReconcileHistogram.WithLabelValues(req.String(), e).Observe(duration)


### PR DESCRIPTION
## Description
Replaces sentry.CaptureException with a logger error to display a proper message on sentry.
Currently shows *fmt.wrapError: https://truefoundry.sentry.io/issues/6173203268

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have performed a self-review of my own code
