### PR TITLE
don't scale up when the scaler check fails

### DIFF
--- a/pkg/scaling/scale_handler.go
+++ b/pkg/scaling/scale_handler.go
@@ -208,7 +208,6 @@ func (h *ScaleHandler) handleScaleFromZero(ctx context.Context, es *v1alpha1.Ela
 		scalerResult, err := scaler.ShouldScaleFromZero(ctx)
 		if err != nil {
 			h.logger.Warn("failed to check scaler", zap.String("namespacedName", namespacedName.String()), zap.Error(err))
-			shouldScale = true
 			break
 		}
 		if scalerResult {


### PR DESCRIPTION
## Description
Do not scale up a service from 0 if the scaler check fails due to it being down, bad request due to improperly created ElastiService or any other case.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have performed a self-review of my own code
