### PR TITLE
Increasing elasti timeout to 10 minutes

### DIFF
--- a/charts/elasti/values.yaml
+++ b/charts/elasti/values.yaml
@@ -51,7 +51,7 @@ elastiResolver:
       operatorRetryDuration: "10"
       queueRetryDuration: "3"
       queueSize: "50000"
-      reqTimeout: "360"
+      reqTimeout: "600"
       trafficReEnableDuration: "5"
     image:
       repository: tfy.jfrog.io/tfy-images/elasti-resolver

--- a/resolver/cmd/main.go
+++ b/resolver/cmd/main.go
@@ -27,7 +27,7 @@ type config struct {
 	MaxIdleProxyConns        int `split_words:"true" default:"1000"`
 	MaxIdleProxyConnsPerHost int `split_words:"true" default:"100"`
 	// ReqTimeout is the timeout for each request
-	ReqTimeout int `split_words:"true" default:"10"`
+	ReqTimeout int `split_words:"true" default:"600"`
 	// TrafficReEnableDuration is the duration for which the traffic is disabled for a host
 	// This is also duration for which we don't recheck readiness of the service
 	TrafficReEnableDuration int `split_words:"true" default:"30"`


### PR DESCRIPTION
## Description
Increasing elasti timeout to 10 minutes

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the default request timeout from 10 seconds to 600 seconds, allowing for longer-running operations before timing out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->