### PR TITLE
fix: port 5000 is used by the systems, using it might be hurdle for u…

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -105,10 +105,12 @@ Enable it in Docker-Desktop
 Run a local Docker registry container, to push our images locally and access them in our cluster.
 
 ```
-docker run -d -p 5000:5000 --name registry registry:2
+docker run -d -p 5001:5000 --name registry registry:2
 ```
 
-> You will need to add this registry to Minikube and Kind, with Docker-Desktop, it is automatically picked up if running in same context.
+> You will need to add this registry to Minikube and Kind. With Docker-Desktop, it is automatically picked up if running in same context.
+
+> Note: In MacOs, 5000 is not available, so we use 5001 instead.
 
 <!-- ### 3. Install NGINX Ingress Controller:
 Install the NGINX Ingress Controller using Helm:
@@ -156,7 +158,7 @@ Go into the resolver directory and run the build and publish command.
 
 ```bash
 cd resolver
-make docker-build docker-push IMG=localhost:5000/elasti-resolver:v1alpha1
+make docker-build docker-push IMG=localhost:5001/elasti-resolver:v1alpha1
 ```
 
 ### 6. Build & Publish Operator
@@ -165,7 +167,7 @@ Go into the operator directory and run the build and publish command.
 
 ```bash
 cd operator
-make docker-build docker-push IMG=localhost:5000/elasti-operator:v1alpha1
+make docker-build docker-push IMG=localhost:5001/elasti-operator:v1alpha1
 ```
 
 ### 7. Deploy Locally
@@ -173,6 +175,7 @@ make docker-build docker-push IMG=localhost:5000/elasti-operator:v1alpha1
 Make sure you have configured the local context in kubectl. We will be using [`./playground/infra/elasti-demo-values.yaml`](./playground/infra/elasti-demo-values.yaml) for the helm installation. Configure the image uri according to the requirement. Post that follow below steps from the project home directory:
 
 ```bash
+kubectl create namespace elasti
 helm template elasti ./charts/elasti -n elasti -f ./playground/infra/elasti-demo-values.yaml | kubectl apply -f -
 ```
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -110,7 +110,7 @@ docker run -d -p 5001:5000 --name registry registry:2
 
 > You will need to add this registry to Minikube and Kind. With Docker-Desktop, it is automatically picked up if running in same context.
 
-> Note: In MacOs, 5000 is not available, so we use 5001 instead.
+> Note: In MacOS, 5000 is not available, so we use 5001 instead.
 
 <!-- ### 3. Install NGINX Ingress Controller:
 Install the NGINX Ingress Controller using Helm:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ generate-manifest: ## Generate deploy manifest
 
 .PHONY: setup-registry
 setup-registry: ## Setup docker registery, where we publish our images
-	docker run -d -p 5000:5000 --name elasti-registry registry:2 
+	docker run -d -p 5001:5000 --name elasti-registry registry:2 
 
 .PHONY: deploy
 deploy: ## Deploy the operator and resolver

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ generate-manifest: ## Generate deploy manifest
 
 .PHONY: setup-registry
 setup-registry: ## Setup docker registery, where we publish our images
-	docker run -d -p 5001:5000 --name elasti-registry registry:2 
+	docker run -d -p 5001:5000 --name registry registry:2 
 
 .PHONY: deploy
 deploy: ## Deploy the operator and resolver

--- a/playground/infra/elasti-demo-values.yaml
+++ b/playground/infra/elasti-demo-values.yaml
@@ -1,7 +1,7 @@
 elastiController:
   manager:
     image:
-      repository: localhost:5000/elasti-operator
+      repository: localhost:5001/elasti-operator
       tag: v1alpha1
     imagePullPolicy: IfNotPresent
     resources:
@@ -14,7 +14,7 @@ elastiController:
 elastiResolver:
   proxy:
     image:
-      repository: localhost:5000/elasti-resolver
+      repository: localhost:5001/elasti-resolver
       tag: v1alpha1
     imagePullPolicy: IfNotPresent
     resources:


### PR DESCRIPTION
# Move playground port from 5000 to 50001

## Description
5000 Port is used by the macOS Control Center.
We can disable it in settings, but that will be a bad Developer Experience. 

Fixes # (issue)
- Move to 5001 port for local docker registry. No conflict with Control Center

## Type of change
Please delete options that are not relevant.

- [x] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

- [x] Tested Locally, following all Development.md steps. 

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes
~- [ ] A PR is open to update the helm chart (link)[https://github.com/truefoundry/elasti/tree/main/charts/elasti] if applicable~
~- [x] I have updated the [CHANGELOG.md](./CHANGELOG.md) file with the changes I made~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated instructions to use Docker registry port 5001 instead of 5000, including clarifications for MacOS users and additional setup notes.
  - Added missing command for namespace creation before deploying the Helm chart.

- **Chores**
  - Changed Docker registry port mapping to 5001 for improved compatibility.
  - Updated image repository URLs in configuration files to reflect the new registry port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->