### PR TITLE
docs fix: wrong information in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Kubernetes clusters can become costly, especially when running multiple services
 
 - [Why use Elasti?](#why-use-elasti)
 - [Contents](#contents)
-  - [Key Features](#key-features)
 - [Introduction](#introduction)
+  - [Key Features](#key-features)
 - [Getting Started](#getting-started)
 - [Configure Elasti](#configure-elasti)
 - [Monitoring](#monitoring)
@@ -33,9 +33,7 @@ Kubernetes clusters can become costly, especially when running multiple services
 
 # Introduction
 
-Elasti is a Kubernetes-native solution that offers scale-to-zero functionality when there is no traffic and automatic scale up to 0 when traffic arrives. Most Kubernetes autoscaling solutions like HPA or Keda can scale from 1 to n replicas based on cpu utilization or memory usage. However, these solutions do not offer a way to scale to 0 when there is no traffic. Elasti solves this problem by dynamically managing service replicas based on real-time traffic conditions. It only handles scaling the application down to 0 replicas and scaling it back up to 1 replica when traffic is detected again. The scaling after 1 replica is handled by the autoscaler like HPA or Keda.
-
-> The name Elasti comes from a superhero "Elasti-Girl" from DC Comics. Her superpower is to expand or shrink her body at will—from hundreds of feet tall to mere inches in height.
+Elasti is a Kubernetes-native solution that offers scale-to-zero functionality when there is no traffic and automatic scale up to 1 when traffic arrives. Most Kubernetes autoscaling solutions like HPA or Keda can scale from 1 to n replicas based on cpu utilization or memory usage. However, these solutions do not offer a way to scale to 0 when there is no traffic. Elasti solves this problem by dynamically managing service replicas based on real-time traffic conditions. It only handles scaling the application down to 0 replicas and scaling it back up to 1 replica when traffic is detected again. The scaling after 1 replica is handled by the autoscaler like HPA or Keda.
 
 Elasti uses a proxy mechanism that queues and holds requests for scaled-down services, bringing them up only when needed. The proxy is used only when the service is scaled down to 0. When the service is scaled up to 1, the proxy is disabled and the requests are processed directly by the pods of the service.
 


### PR DESCRIPTION
## Description

Fix for issue: #129 

"scale up to 0 when traffic arrives." -> "scale up to 1 when traffic arrives." in Readme




## Type of change

- [x] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the table of contents for improved clarity.
  * Clarified the description of scaling behavior in the Introduction.
  * Removed redundant information about the origin of the name "Elasti."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->